### PR TITLE
Add round wise leaderboard

### DIFF
--- a/src/components/Cards/index.jsx
+++ b/src/components/Cards/index.jsx
@@ -9,6 +9,7 @@ export const RoundCard = (props) => {
       <Col  span={8}>
         <Card className="card" title={props.title} extra={(props.status === 1) ? <Tag color="#2db7f5">Scheduled</Tag> : (props.status === 2) ? <Tag color="#87d068">In process</Tag> : <Tag color="#f50">Finished</Tag>}>
           <Button onClick={ event => { navigate(`/app/events/${props.eventId}/rounds/${props.id}/slot`) }} className="btn" size="large" block type="secondary"> Generate Slots </Button>
+          <Button onClick={ event => { navigate(`app/events/${props.eventId}/rounds/${props.id}/leaderboard`); }} className="btn" size="large" block type="secondary"> View Leaderboard </Button>
           <Button onClick={ event => { navigate(`app/judge/${props.eventId}/rounds/${props.id}`); }} className="btn" size="large" block type="primary"> Start Judging </Button>
         </Card>
       </Col>

--- a/src/components/GenerateSlots/index.jsx
+++ b/src/components/GenerateSlots/index.jsx
@@ -239,9 +239,10 @@ export default class GenerateSlots extends Component {
         key: 'team',
       }];
       
-      dataSource = json.data.map(data=>{
+      dataSource = json.data.map((data,k)=>{
         console.log(data);
         return {
+          key: k,
           slot:data.number,
           team:data.teamName
         }

--- a/src/components/GenerateSlots/index.jsx
+++ b/src/components/GenerateSlots/index.jsx
@@ -310,7 +310,16 @@ export default class GenerateSlots extends Component {
               <tr><th>Slot. No. </th><th>Team Name</th></tr>
               </thead>
               <tbody>
-              {this.state.slots.map(slot=><tr><th>{slot.number}</th><th id={"team-"+slot.number} >{slot.teamName}</th></tr>)}
+              {
+                this.state.slots.map((slot, k) => {
+                  return (
+                    <tr key={k}>
+                      <th>{slot.number}</th>
+                      <th id={"team-"+slot.number} >{slot.teamName}</th>
+                    </tr>
+                  )
+                })
+              }
               </tbody>
           </table>
           </div>

--- a/src/components/Leaderboard/index.jsx
+++ b/src/components/Leaderboard/index.jsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { List } from "antd";
+import constants from "../../utils/constants";
+
+export default class extends React.PureComponent {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      leaderboard: [],
+    };
+  }
+
+  componentWillMount = () => {
+    fetch(
+      constants.server
+        + "/events/"
+        + this.state.eventId
+        + "/rounds/"
+        + this.state.roundId
+        + "/leaderboard"
+    ).then(res => res.json()).then(res => {
+      this.setState({
+        leaderboard: res.data.sort((a, b) => parseFloat(b.points) - parseFloat(a.points)),
+      });
+    });
+  }
+
+  render() {
+    return (
+      <List
+        itemLayout="horizontal"
+        dataSource={this.state.leaderboard}
+        renderItem={(item, i) => (
+          <List.Item>
+            <List.Item.Meta
+              title={ (i + 1) + ". " + item.college }
+              description={ item.points + " points "}
+              style={{
+                cursor: "pointer",
+              }}
+            />
+          </List.Item>
+        )}
+      />
+    );
+  }
+};

--- a/src/components/Leaderboard/index.jsx
+++ b/src/components/Leaderboard/index.jsx
@@ -15,15 +15,15 @@ export default class extends React.PureComponent {
     fetch(
       constants.server
         + "/events/"
-        + this.state.eventId
+        + this.props.event
         + "/rounds/"
-        + this.state.roundId
+        + this.props.round
         + "/leaderboard"
     ).then(res => res.json()).then(res => {
       this.setState({
         leaderboard: res.data.sort((a, b) => parseFloat(b.points) - parseFloat(a.points)),
       });
-    });
+    })
   }
 
   render() {
@@ -34,7 +34,7 @@ export default class extends React.PureComponent {
         renderItem={(item, i) => (
           <List.Item>
             <List.Item.Meta
-              title={ (i + 1) + ". " + item.team }
+              title={ (i + 1) + ". " + item.team.name }
               description={ item.points + " points "}
               style={{
                 cursor: "pointer",

--- a/src/components/Leaderboard/index.jsx
+++ b/src/components/Leaderboard/index.jsx
@@ -34,7 +34,7 @@ export default class extends React.PureComponent {
         renderItem={(item, i) => (
           <List.Item>
             <List.Item.Meta
-              title={ (i + 1) + ". " + item.college }
+              title={ (i + 1) + ". " + item.team }
               description={ item.points + " points "}
               style={{
                 cursor: "pointer",

--- a/src/pages/app.jsx
+++ b/src/pages/app.jsx
@@ -9,15 +9,16 @@ import Profile from "../components/Profile";
 import Judge from "../components/Judge";
 import Layout from '../layouts/app/index';
 import GenerateSlots from "../components/GenerateSlots";
+import Leaderboard from "../components/Leaderboard";
 
 export default class Views extends React.Component {
   render() {
     return (
       <Layout>
         <Router>
-          { /* TODO: Profile is a temporary page to test login. */}
           <PrivateRoute path="/app" component={Profile} />
           <PrivateRoute path="/app/registration" component={Registration} />
+          <PrivateRoute path="/app/events/:event/rounds/:round/leaderboard" component={Leaderboard} exact />
           <Login path="/app/login" />
           <RoundList path="/app/events/:event/rounds" exact/>
           <EventList path="app/events" />

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -14,5 +14,5 @@ export default {
     white: "#ffffff",
   },
   //server:"http://localhost:3003"//express server
-  server:"https://utsavb.bastionbot.org" //express server
+  server:"http://142.93.215.102" //express server
 };


### PR DESCRIPTION
Note that the leaderboard currently only shows the team ID, so if some component is storing the team details in localstorage, we can use that to get the college name from the it, otherwise we'll have to make another request to the API to get all team names for the round as shown below:
```jsx
      // Add this to /src/components/Leaderboard/index.jsx:23 and try if it works.
      fetch(
        constants.server
          + "/events/"
          + this.state.eventId
          + "/rounds/"
          + this.state.roundId
          + "/teams"
      ).then(res => res.json()).then(teamRes => {
        for (let team of teamRes) {
          res.data.map(score => {
            if (team.id === score.team) score.team = team.name;
            return score;
          });
        }

        this.setState({
          leaderboard: res.data.sort((a, b) => parseFloat(b.points) - parseFloat(a.points)),
        });
      });
```