### PR TITLE
Volunteer college name

### DIFF
--- a/src/components/Volunteer/CoreVolunteer.jsx
+++ b/src/components/Volunteer/CoreVolunteer.jsx
@@ -224,7 +224,7 @@ class CoreVolunteer extends React.Component {
                                         <td>{volunteer.name}</td>
                                         <td>{volunteer.registerNumber}</td>
                                         <td>{volunteer.shirtSize}</td>
-                                        <td>{volunteer.college}</td>
+                                        <td>{volunteer.college && volunteer.college.name || volunteer.college}</td>
                                         <td></td>
                                     </tr>
                                 ))

--- a/src/components/Volunteer/EventVolunteer.jsx
+++ b/src/components/Volunteer/EventVolunteer.jsx
@@ -178,7 +178,7 @@ class EventVolunteer extends React.Component {
                                         <td>{index + 1}</td>
                                         <td>{volunteer.name}</td>
                                         <td>{volunteer.registerNumber}</td>
-                                        <td>{volunteer.college}</td>
+                                        <td>{volunteer.college && volunteer.college.name || volunteer.college}</td>
                                         <td></td>
                                     </tr>
                                 ))


### PR DESCRIPTION
Show volunteer college name instead of id. Also, use ID as fallback if college name/object isn't available.