### PR TITLE
Backwards timer for registrations closing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "jszip": "^3.2.2",
         "postcss": "^8.4.20",
         "react": "^16.8.3",
+        "react-countdown": "^2.3.5",
         "react-datepicker": "^2.1.0",
         "react-dom": "^16.8.3",
         "react-icons": "^3.11.0",
@@ -16542,6 +16543,18 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-countdown": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/react-countdown/-/react-countdown-2.3.5.tgz",
+      "integrity": "sha512-K26ENYEesMfPxhRRtm1r+Pf70SErrvW3g4CArLi/x6MPFjgfDFYePT4UghEj8p2nI0cqVV7/JjDgjyr//U60Og==",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": ">= 15",
+        "react-dom": ">= 15"
       }
     },
     "node_modules/react-datepicker": {
@@ -33306,6 +33319,14 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2"
+      }
+    },
+    "react-countdown": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/react-countdown/-/react-countdown-2.3.5.tgz",
+      "integrity": "sha512-K26ENYEesMfPxhRRtm1r+Pf70SErrvW3g4CArLi/x6MPFjgfDFYePT4UghEj8p2nI0cqVV7/JjDgjyr//U60Og==",
+      "requires": {
+        "prop-types": "^15.7.2"
       }
     },
     "react-datepicker": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "jszip": "^3.2.2",
     "postcss": "^8.4.20",
     "react": "^16.8.3",
+    "react-countdown": "^2.3.5",
     "react-datepicker": "^2.1.0",
     "react-dom": "^16.8.3",
     "react-icons": "^3.11.0",

--- a/src/components/Index/index.jsx
+++ b/src/components/Index/index.jsx
@@ -1,9 +1,50 @@
 import React from "react";
 import utsavLogo from "../../images/loader.gif"
+import Countdown from 'react-countdown';
+
+const cookingEventsOpenDate = new Date("February 27, 2023, 23:59:59");
+const cookingEventsCloseDate = new Date("March 4, 2023, 00:00:00");
+const studentEventsOpenDate = new Date("March 20, 2023, 00:00:00");
+const studentEventsCloseDate = new Date("April 1, 2023, 23:59:59");
+
+const renderer = ({ days, hours, minutes, seconds, completed }) => {
+  if (completed) {
+    return <span>registrations are closed!</span>;
+  } else {
+    if(days == 0 && hours == 0 && minutes == 0) {
+      return <span>registrations close in: {seconds} seconds</span>;
+    } else if(days == 0 && hours == 0) {
+      return <span>registrations close in: {minutes} minutes and {seconds} seconds</span>;
+    } else if (days == 0) {
+      return <span>registrations close in: {hours} hours, {minutes} minutes and {seconds} seconds</span>;
+    } else {
+      return <span>registrations close in: {days} days, {hours} hours, {minutes} minutes and {seconds} seconds</span>;
+    }
+  }
+};
+
+const RegistrationTimer = () => {
+  const current_date = new Date();
+  if(current_date >= studentEventsOpenDate) {
+    return (<>
+              <span>Student event </span>
+              <Countdown date={studentEventsCloseDate} renderer={renderer} />
+          </>)
+  } else if(current_date >= cookingEventsOpenDate) {
+    return  (<>
+              <span>Cooking event </span>
+              <Countdown date={cookingEventsCloseDate} renderer={renderer} />
+          </>)
+  } 
+  return <></>
+
+}
+
 export default () =>
   <div css={{ textAlign: "center" }}>
     <h2 className="mucapp">Welcome to MUCAPP!</h2>
     <h1 className="mucapp"> UTSAV 2023</h1>
+    <RegistrationTimer />
     <img className="mucapp" css={{ width: "60%" }} alt="Logo" src={utsavLogo} />
   </div >
   ;


### PR DESCRIPTION
I've implemented and tested the backwards timer for registrations closing. Testing has been done on Chrome for Windows. As for the dates for the opening and closing of the registrations, I've used the ones mentioned by Sambit during the last meeting. The timer only shows after registrations open, so for testing set your local time ahead. 